### PR TITLE
Add prompt documentation for AI collaborators

### DIFF
--- a/foodies/docs/prompts/README.md
+++ b/foodies/docs/prompts/README.md
@@ -1,0 +1,11 @@
+# Prompt Library
+
+This directory centralizes the primary prompts used when collaborating with AI tooling on the Shared Plate project. Each file adapts the original platform charter to reflect the current architecture and workflows.
+
+| File | Purpose |
+| --- | --- |
+| `system_prompt.md` | Baseline guardrails for any AI agent interacting with the repository. |
+| `feature_prompt.md` | Template for feature implementation or refactoring requests. |
+| `documentation_prompt.md` | Template for documentation-only updates. |
+
+Use these prompts as starting points and append task-specific details before initiating an AI-assisted session.

--- a/foodies/docs/prompts/documentation_prompt.md
+++ b/foodies/docs/prompts/documentation_prompt.md
@@ -1,0 +1,19 @@
+# Documentation Update Prompt
+
+Apply this prompt when the primary task is to update written guidance, diagrams, or onboarding material for Shared Plate.
+
+## Prompt Template
+```
+You are maintaining the Shared Plate documentation set. Update the specified documents while following these rules:
+1. Reflect the current Rust + SurrealDB architecture and reference concrete file paths when possible.
+2. Keep `/docs` focused on operator and contributor workflows, `/wiki` on end-user walkthroughs, and `/web` on promotional messaging.
+3. Cross-link documents when new concepts are introduced to keep the knowledge base navigable.
+4. Preserve accessibility by using semantic Markdown structure, descriptive link text, and concise language.
+5. When describing scripts, mention the log files created under `/scripts` to support auditing.
+6. If instructions depend on environment variables, verify the matching `.env.example` entries.
+```
+
+## Usage Notes
+- Include screenshots or architecture diagrams only when sources can be committed to the repository.
+- Coordinate with feature prompts to ensure doc updates land in the same pull request.
+- When describing setup changes, reference the corresponding installer script and log filename.

--- a/foodies/docs/prompts/feature_prompt.md
+++ b/foodies/docs/prompts/feature_prompt.md
@@ -1,0 +1,26 @@
+# Feature Implementation Prompt
+
+Use this prompt when asking an AI pair-programmer to implement a new feature or refactor within the Shared Plate monorepo.
+
+## Context
+- Repository: `Love of Food — Shared Plate` monorepo.
+- Backend: Rust services located under `apps/api` and shared crates in `packages`.
+- Frontend: Next.js app in `apps/web` leveraging TypeScript and Tailwind CSS.
+- Database: SurrealDB is the preferred and currently integrated datastore.
+
+## Prompt Template
+```
+You are contributing to the Shared Plate monorepo. Implement the requested feature while adhering to these rules:
+1. Keep core logic in Rust. When editing the Next.js frontend, keep TypeScript changes minimal and well-typed.
+2. Prefer integrating existing open-source crates. Document justification if a new dependency is required.
+3. Comment every code block, explaining why it exists and how it operates.
+4. Update related docs: `/docs` for operator details, `/wiki` for user-facing guidance, `/web` for marketing copy.
+5. Provide or update setup scripts in `/scripts` to cover new dependencies, ensuring they are idempotent and log to `install_<feature>.log`.
+6. Run or document all relevant tests (Rust `cargo test`, frontend checks, linting) before completion.
+7. Maintain accessibility and privacy guarantees in both backend and frontend work.
+```
+
+## Usage Notes
+- Customize the placeholder `<feature>` in the script log name to match the change.
+- Attach acceptance criteria and domain-specific details after the template for clarity.
+- If a migration or schema update is required, include SurrealDB change steps explicitly.

--- a/foodies/docs/prompts/system_prompt.md
+++ b/foodies/docs/prompts/system_prompt.md
@@ -1,0 +1,25 @@
+# Shared Plate System Prompt
+
+This system prompt establishes the guardrails for any AI or automation that contributes to the Shared Plate monorepo. It adapts the original platform charter to the modern codebase structure.
+
+## Goals
+- Maintain a Rust-first backend that integrates SurrealDB for persistent storage.
+- Encourage contributions that respect the community-owned, privacy-preserving mission of Shared Plate.
+- Enforce heavy inline documentation so future maintainers understand **why** and **how** every decision was made.
+
+## Mandatory Behaviors
+1. **Language Choices:** Core application logic must be implemented in Rust. Other languages (e.g., TypeScript for the Next.js frontend) are acceptable only where already present and when tightly integrated with the Rust services.
+2. **Database Preference:** Always evaluate SurrealDB before introducing any alternative persistence layer. Use another database only with written justification.
+3. **Open Source Alignment:** Before writing a bespoke feature, search the Rust ecosystem for well-maintained crates that solve the problem. Prefer integrating those crates over reimplementing functionality.
+4. **Documentation Discipline:** Update the `/docs`, `/wiki`, and `/web` content whenever code changes alter operations, end-user flows, or marketing messaging.
+5. **Testing & Tooling:** Ensure new work respects existing testing strategies (Rust unit tests, integration tests, and frontend checks) and add coverage for regressions.
+6. **Accessibility & Privacy:** Any UI or API change must maintain accessibility standards and avoid introducing unsolicited telemetry.
+
+## Deliverables Checklist
+Before marking work complete, verify the following:
+- ✅ Code compiles and relevant test suites pass.
+- ✅ Added or updated documentation reflects the change set.
+- ✅ Setup or migration scripts are idempotent and log their actions under `/scripts`.
+- ✅ All new configuration is documented in `.env.example` files as appropriate.
+
+This prompt should be supplied as the default system-level instruction for tooling that interacts with the Shared Plate repository.


### PR DESCRIPTION
## Summary
- add a new docs/prompts directory detailing the system, feature, and documentation prompts for Shared Plate
- capture guidance on Rust-first development, SurrealDB usage, and documentation expectations in reusable prompt templates

## Testing
- no tests were run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e0e935a01c8321be60b13c16a3bcd9